### PR TITLE
Migrated server-maintenance from the old wiki

### DIFF
--- a/docs/en/server/create-a-server.md
+++ b/docs/en/server/create-a-server.md
@@ -12,7 +12,7 @@ Servers are an integral part of BeamMP; players are connected to each other thro
 
 You can make private servers, which only people you invite can join, or public servers, which will show in our official server list.
 
-Getting a server up and running is a process with a few steps! It's quite easy, but if you run into any issues, feel free to ask on our [Forum](https://forum.beammp.com) or on our [Discord server](https://discord.gg/beammp) in the `#support` channel. Also refer to the [Server Maintenance](https://wiki.beammp.com/en/home/server-maintenance) section for more info. 
+Getting a server up and running is a process with a few steps! It's quite easy, but if you run into any issues, feel free to ask on our [Forum](https://forum.beammp.com) or on our [Discord server](https://discord.gg/beammp) in the `#support` channel. Also refer to the [Server Maintenance](server-maintenance.md) section for more info. 
 
 Please make sure to read the [LICENSE](https://raw.githubusercontent.com/BeamMP/BeamMP-Server/master/LICENSE) of the server before use.
 
@@ -148,7 +148,7 @@ Port = 30814
 Private = false
 ResourceFolder = 'Resources'
 ```
-This is your configuration file. It uses a format called TOML. Refer to the [Server Maintenance](https://wiki.beammp.com/en/home/server-maintenance) section for more info on this file.
+This is your configuration file. It uses a format called TOML. Refer to the [Server Maintenance](server-maintenance.md) section for more info on this file.
 
 For now, we only care about the `AuthKey` field. Between the quotes `''`, you want to paste in your AuthKey you copied in the first step.
 
@@ -156,7 +156,7 @@ For our example key, it should then look like this:
 ```TOML
 AuthKey = '3173a2e-6az0-4542-a3p0-ddqq5ff95558'
 ```
-Give your server a name, too, in the `Name` field. You can format this with colors and more, please refer to [this section on Name customization](https://wiki.beammp.com/en/home/server-maintenance#customize-the-look-of-your-server-name) in the server maintenance page.
+Give your server a name, too, in the `Name` field. You can format this with colors and more, please refer to [this section on Name customization](server-maintenance.md#customize-the-look-of-your-server-name) in the server maintenance page.
 
 If you picked a different **Port** other than **30814**, make sure to replace it here under `Port`.
 
@@ -179,7 +179,7 @@ If you only wanted to add modded vehicles, you simply put the zip file of the mo
 
 ### Maps
 
-All default maps (maps which aren't mods) work out-of-the-box and do not have to be installed. You simply change the `Map` setting in the `ServerConfig.toml` file to any of [these](https://wiki.beammp.com/en/home/server-maintenance#all-vanilla-maps-names). For any other modded maps, do this:
+All default maps (maps which aren't mods) work out-of-the-box and do not have to be installed. You simply change the `Map` setting in the `ServerConfig.toml` file to any of [these](server-maintenance.md#all-vanilla-maps-names). For any other modded maps, do this:
 
 1.  Put your map's `.zip` file in your server's (`Resources/Client`) folder.
 2.  Next, have a look inside the map's zip file (don't extract it) and open the `levels` folder. In this folder there should be simply one other folder with the name of the map, for example “myawesomedriftmap2021”. Make sure to copy or remember this name _exactly as it is written in that folder's name._

--- a/docs/en/server/server-maintenance.md
+++ b/docs/en/server/server-maintenance.md
@@ -1,0 +1,147 @@
+# Server Maintenance
+
+Guides, tips and tricks on how to configure and take care of a BeamMP Server.
+
+## How to install
+
+For installation instructions, please see [server installation](create-a-server.md).
+
+## The ServerConfig file
+
+The server config, which is a file called `ServerConfig.toml`, uses the [TOML format](https://toml.io/en/).
+
+*NOTE*: The *old* server config file was called `Server.cfg`, but this is no longer used, and the server will warn when this is still present. Please also note that the two config formats are **not** compatible with each other.
+
+The config has one section by default, called `[General]`, which holds the following values:
+
+| Key         | Value Type                                                                                                           | Description                                                                                                                                                                                 |
+|-------------|----------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| AuthKey     | AuthKey format `xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` where all x's are alphanumeric characters (numbers and letters) | Used to identify your server with the backend. You should have gotten one while following the installation instructions.                                                                    |
+| Debug       | true /false                                                                                                          | When enabled (true), will show more messages in the log and provide more information. Enable this if you run into issues. Enabling this will drastically increase the size of the log file. |
+| Private     | true/false                                                                                                           | When enabled (true), your server will not be shown in the server list. Anyone with the correct IP and port can still connect.                                                               |
+| Description | Any "text"                                                                                                           | Shown as the description of the server in the server list (if the server is public). You can use special characters to format this with colors and styles.                                  |
+| Name        | Any "text"                                                                                                           | Shown as the name / title of your server in the server list. You can use special characters to format this with colors and styles.                                                          |
+| Map         | A valid map location, such as `/levels/gridmap_v2/info.json`                                                         | The map your server will host. Has to be installed either by default (a list can be found below) or as a server mod.                                                                        |
+| MaxCars     | Any number ≥ 1                                                                                                       | The maximum number of cars per player. Any additional cars a player tries to spawn will be deleted instantly.                                                                               |
+| Port        | 1024-65535                                                                                                           | The networking port on which the server will be accessible. For a player to connect to your server directly, they will need your IP and this port.                                          |
+
+Other sections can and should be used by server plugins (Lua API coming soon), like so: `[MyMod]`.
+
+The AuthKey **HAS** to be set by you. It will be empty by default, and needs to be filled with your AuthKey from the installation step earlier. Do not share this Key with anyone and, in screenshots, blur it fully.
+
+### All vanilla maps names
+
+Here are all the stock maps:
+
+- /levels/gridmap_v2/info.json
+- /levels/johnson_valley/info.json
+- /levels/automation_test_track/info.json
+- /levels/east_coast_usa/info.json
+- /levels/hirochi_raceway/info.json
+- /levels/italy/info.json
+- /levels/jungle_rock_island/info.json
+- /levels/industrial/info.json
+- /levels/small_island/info.json
+- /levels/smallgrid/info.json
+- /levels/utah/info.json
+- /levels/west_coast_usa/info.json
+- /levels/driver_training/info.json
+- /levels/derby/info.json
+
+### Customize the look of your server name
+
+Use these special symbols before your text and it'll apply an effect to that text in the server list:
+
+| Value | Description                 |
+|:-----:|-----------------------------|
+| `^r`  | Reset                       |
+| `^p`  | Newline (descriptions only) |
+| `^n`  | Underline                   |
+| `^l`  | Bold                        |
+| `^m`  | Strike-through              |
+| `^o`  | Italic                      |
+| `^0`  | Black                       |
+| `^1`  | Blue                        |
+| `^2`  | Green                       |
+| `^3`  | Light blue                  |
+| `^4`  | Red                         |
+| `^5`  | Pink                        |
+| `^6`  | Orange                      |
+| `^7`  | Grey                        |
+| `^8`  | Dark grey                   |
+| `^9`  | Light purple                |
+| `^a`  | Light green                 |
+| `^b`  | Light blue                  |
+| `^c`  | Dark orange                 |
+| `^d`  | Light pink                  |
+| `^e`  | Yellow                      |
+| `^f`  | White                       |
+
+## The Server.log file
+
+This file will be generated when the server runs. It's a mirror of the messages you see in the console when you run the server. You should attach this file every time you need support from our support staff, and it will never show your AuthKey, so you can usually send it without modifications.
+
+The format is as follows ($ prefix means “variable”, explained below):
+
+```
+[$DATE $TIME] $CONTEXT [$LOG_LEVEL] $MESSAGE
+```
+
+Where:
+
+- `$DATE` is the date of the message, for example 21/07/2021
+- `$TIME` is the time of the message, for example 11:05:23
+- `$CONTEXT` (only visible if in Debug mode and mostly relevant to developers) is the context of the message, which is either:
+	- `(Player ID) “Player Name”`, where the Player's ID is useful for moderation
+	- A short name such as “HeartbeatThread”
+- `$LOG_LEVEL` is one of the levels of importance of a message:
+	- `DEBUG`: Only visible in Debug mode, usually spammy and only important to developers
+	- `INFO`: General information
+	- `LUA`: Message from a Lua plugin
+	- `WARN`: Describes something that isn't supposed to happen, usually
+	- `ERROR`: Something went very wrong, or was very unexpected
+	- `FATAL`: Something happened that causes the server to shut down
+- `$MESSAGE` the message itself, usually something that you should pay attention to and understand. In some cases this might be cryptic, but the general rule is that, as long as nothing is visibly wrong with the server and there are no ERRORs, all is good.
+
+## Updating the server
+
+### Why to update
+
+Whenever a new update is released, you're advised to update your server. Usually this involves bug fixes, stability improvements and security improvements, next to the general new features etc. that are introduced.
+
+To receive news about updates when they come out, either follow the discord server's “update” channel, look out for it on the forums, or look at / ask the [GitHub releases page](https://github.com/BeamMP/BeamMP-Server/releases).
+
+### How to update
+
+#### If you are using a BeamMP partnered hosting provider
+
+If you are using a BeamMP partnered hosting provider, the instructions below likely won't work. We recommend waiting for more details from your hosting provider, or contacting them for assistance.
+
+#### Managing the server yourself
+
+The server is updated by replacing the old executable with the new one. If you are unsure how to do this, there are step-by-step instructions for Windows and Linux below.
+
+If you built from source, you just rebuild. Make sure to run `git submodule update --init --recursive` before you rebuild.
+
+#### On Windows
+
+1. Ensure you have installed the [Visual C++ Redistributables](https://aka.ms/vs/17/release/vc_redist.x64.exe) in order to run the server.
+2. Go to [BeamMP.com](https://beammp.com/) and click the “Download Server” button.
+3. Once downloaded, you should see one file called `BeamMP-Server.exe`. We will call this one the “new executable”.
+4. Go to the folder where your current `BeamMP-Server.exe` executable is located (same folder where your `ServerConfig.toml` is, usually). We will call this one the “old executable”.
+5. Replace the old executable with the new executable (for example by copying or moving the new executable into the folder).
+
+#### On Linux
+
+1. Go to [BeamMP.com](https://beammp.com/) and click the “Download Server” button, you will be redirected to the server's Github release page.
+2. Download the correct version for your distro. For sake of semplicity it will be called `BeamMP-Server-xxx` from now on, where `xxx` denotes the version for the distro you're using.
+3. Once downloaded, you should see one file called `BeamMP-Server-xxx` depending on the version you've downloaded. We will call this one the “new executable”.
+4. Go to the folder where your current `BeamMP-Server-xxx` executable is located (same folder where your `ServerConfig.toml` is, usually). We will call this one the “old executable”.
+5. Replace the old executable with the new executable (for example by copying or moving the new executable into the folder).
+6. Open a terminal in that folder where you just replaced the executable, and run `sudo chmod +x BeamMP-Server-xxx`. This will make sure the server can be run.
+
+### Automated updates
+
+The server does not support automatic updates or update notifications (yet).
+
+You can, however, ask the GitHub API for the lastest release by checking the server's version against the tags. You can get that by GET'ing from `https://api.github.com/repos/BeamMP/BeamMP-Server/git/refs/tags`.

--- a/docs/it/server/create-a-server.md
+++ b/docs/it/server/create-a-server.md
@@ -12,7 +12,7 @@ I server sono una parte integrante di BeamMP, tutti i giocatori sono connessi tr
 
 Puoi creare server privati, ai quali si possono connettere solo persone che inviti, o server pubblici, che saranno visibili sulla nostra ufficiale lista di server.
 
-Per far funzionare correttamente un server è necessario seguire alcuni passi! È abbastanza semplice, ma se hai dei problemi, chiedi pure sul nostro [Forum](https://forum.beammp.com) o sul nostro [server Discord](https://discord.gg/beammp) nel canale `#support`. Fai anche riferimento alla sezione di [Manutenzione Server](https://wiki.beammp.com/en/home/server-maintenance) per ulteriori informazioni.
+Per far funzionare correttamente un server è necessario seguire alcuni passi! È abbastanza semplice, ma se hai dei problemi, chiedi pure sul nostro [Forum](https://forum.beammp.com) o sul nostro [server Discord](https://discord.gg/beammp) nel canale `#support`. Fai anche riferimento alla sezione di [Manutenzione Server](server-maintenance.md) per ulteriori informazioni.
 
 Assicurati di aver letto e compreso la [LICENZA](https://raw.githubusercontent.com/BeamMP/BeamMP-Server/master/LICENSE) del server prima dell'uso.
 
@@ -147,7 +147,7 @@ Private = false
 ResourceFolder = 'Resources'
 ```
 
-Questo è il tuo file di configurazione. Utilizza un formato chiamato TOML. Fai anche riferimento alla sezione di [Manutenzione Server](https://wiki.beammp.com/en/home/server-maintenance) per maggiori informazioni.
+Questo è il tuo file di configurazione. Utilizza un formato chiamato TOML. Fai anche riferimento alla sezione di [Manutenzione Server](server-maintenance.md) per maggiori informazioni.
 
 Per ora ci interessa soltanto il campo `AuthKey`. Incolla tra le virgolette `''` la chiave ottenuta nel passo "2\. Ottenere una chiave di autenticazione".
 
@@ -156,7 +156,7 @@ Per questo esempio, dovrà essere così:
 AuthKey = '3173a2e-6az0-4542-a3p0-ddqq5ff95558'
 ```
 
-Dai anche un nome al tuo server tramite il campo `Name`. Puoi utilizzare colori e altri tipi di formattazione seguendo le indicazioni di [questa sezione](https://wiki.beammp.com/en/home/server-maintenance#customize-the-look-of-your-server-name) della pagina di manutenzione del server.
+Dai anche un nome al tuo server tramite il campo `Name`. Puoi utilizzare colori e altri tipi di formattazione seguendo le indicazioni di [questa sezione](server-maintenance.md#personalizza-laspetto-del-nome-del-tuo-server) della pagina di manutenzione del server.
 
 Se hai scelto una **porta** differente da **30814** inseriscila al posto di quella predefinita in `Port`.
 
@@ -178,7 +178,7 @@ Se ti interessa aggiungere mod di veicoli, basta aggiungerle alla cartella `Reso
 
 ### Mappe
 
-Tutte le mappe ufficiali del gioco (quindi che non sono mod) non necessitano di essere installate, devi soltanto cambiare il valore del campo `Map` del file `ServerConfig.toml` con una di [queste stringhe](https://wiki.beammp.com/en/home/server-maintenance#all-vanilla-maps-names). Per mappe non ufficiali (mod), bisogna fare così:
+Tutte le mappe ufficiali del gioco (quindi che non sono mod) non necessitano di essere installate, devi soltanto cambiare il valore del campo `Map` del file `ServerConfig.toml` con una di [queste stringhe](server-maintenance.md#tutti-i-nomi-delle-mappe-vanilla). Per mappe non ufficiali (mod), bisogna fare così:
 
 1. Inserire il file `.zip` della mappa nella cartella `Resources/Client` all'interno della cartella del server.
 2. Apri il file `.zip` della mappa senza estrarlo e naviga alla cartella `/levels/`. In questa cartella ce ne dovrebbe essere un'altra con il nome della mappa, ad esempio `myawesomedriftmap2021`. Copia o ricordati questo nome _esattamente come è scritto su tale cartella_.

--- a/docs/it/server/server-maintenance.md
+++ b/docs/it/server/server-maintenance.md
@@ -1,0 +1,147 @@
+# Manutenzione del server
+
+Guide e suggerimenti per come configurare e mantenere al meglio il Server BeamMP.
+
+## Come installare
+
+Per delle istruzioni dettagliate, per favore guarda [la nostra guida](create-a-server.md).
+
+## Il file ServerConfig
+
+Il file per la configurazione del server, chiamato `ServerConfig.toml`, è in [formato TOML](https://toml.io/en/).
+
+*NOTA*: Il *vecchio* file di configurazione chiamato `Server.cfg`, non è più utilizzato e il server ti avviserà nel caso sia ancora presente. I due formati di configurazione **non** sono compatibili tra loro.
+
+Il file ha una sezione di default chiamata `[General]`, che contiene i seguenti valori:
+
+| Chiave      | Tipo di valore                                                                                                       | Descrizione                                                                                                                                                                                                          |
+|-------------|----------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| AuthKey     | Formato della AuthKey `xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` dove le x sono caratteri alfanumerici (numeri e lettere) | Usato per identificare il tuo server nel backend. Dovresti averne una avendo seguito la guida di installazione del server.                                                                                           |
+| Debug       | true /false                                                                                                          | Quando è abilitato (true) mostrerà diversi messaggi in più nei log e fornirà più informazioni. Abilita questo valore se incontri dei problemi. Abilitare questo valore farà aumentare la dimensione del file di log. |
+| Private     | true/false                                                                                                           | Quando è abilitato (true) il tuo server non sarà visibile nella lista pubblica dei server. Le persone con l'IP e la porta del server potranno però connettersi.                                                      |
+| Description | Qualunque "testo"                                                                                                    | La descrizione del server sarà visibile a tutti (se il server è pubblico). Puoi usare caratteri speciali per formattare il testo con diversi colori e stili.                                                         |
+| Name        | Qualunque "testo"                                                                                                    | Il nome / titolo del tuo server che apparirà nella lista dei server. Puoi usare caratteri speciali per formattare il testo con diversi colori e stili.                                                               |
+| Map         | Una posizione valida della mappa, come `/levels/gridmap_v2/info.json`                                                | La mappa del tuo server. Può essere una delle mappe predefinite del gioco (una lista di tali mappe è presente qui sotto) o come una mod del server.                                                                  |
+| MaxCars     | Qualunque numero ≥ 1                                                                                                 | Il numero massimo di veicoli per giocatore. Ulteriori veicoli che un giocatore proverà a caricare saranno rimossi immediatamente.                                                                                    |
+| Port        | 1024-65535                                                                                                           | La porta sulla quale il server sarà raggiungibile. Un giocatore che volesse connettersi direttamente al tuo server necessiterà del tuo IP e di questa porta.                                                         |
+
+Altre sezioni possono e devono essere usate dai plugin del server (la API Lua è in arrivo), così: `[MyMod]`.
+
+La AuthKey **DEVE** essere impostata da te. Di base sarà un valore vuoto che dovrà essere riempito con con la tua AuthKey ottenuta seguendo la guida di installazione. Non condividere questa chiave con nessuno e negli screenshot offuscala.
+
+### Tutti i nomi delle mappe vanilla
+
+Di seguito ci sono tutte le mappe vanilla:
+
+- /levels/gridmap_v2/info.json
+- /levels/johnson_valley/info.json
+- /levels/automation_test_track/info.json
+- /levels/east_coast_usa/info.json
+- /levels/hirochi_raceway/info.json
+- /levels/italy/info.json
+- /levels/jungle_rock_island/info.json
+- /levels/industrial/info.json
+- /levels/small_island/info.json
+- /levels/smallgrid/info.json
+- /levels/utah/info.json
+- /levels/west_coast_usa/info.json
+- /levels/driver_training/info.json
+- /levels/derby/info.json
+
+### Personalizza l'aspetto del nome del tuo server
+
+Puoi usare questi simboli prima del tuo testo per applicarci un effetto:
+
+| Valore | Descrizione                      |
+|:------:|----------------------------------|
+| `^r`   | Reset                            |
+| `^p`   | A capo (solo per le descrizioni) |
+| `^n`   | Sottolineato                     |
+| `^l`   | Grassetto                        |
+| `^m`   | Barrato                          |
+| `^o`   | Corsivo (italico)                |
+| `^0`   | Nero                             |
+| `^1`   | Blu                              |
+| `^2`   | Verde                            |
+| `^3`   | Turchese                         |
+| `^4`   | Rosso                            |
+| `^5`   | Rosa                             |
+| `^6`   | Arancione                        |
+| `^7`   | Grigio                           |
+| `^8`   | Grigio scuro                     |
+| `^9`   | Viola chiaro                     |
+| `^a`   | Verde chiaro                     |
+| `^b`   | Azzurro                          |
+| `^c`   | Arancione scuro                  |
+| `^d`   | Rosa chiaro                      |
+| `^e`   | Giallo                           |
+| `^f`   | Bianco                           |
+
+## Il file Server.log
+
+Questo file è generato automaticamente quando il server è avviato. Contiene tutti i messaggi visualizzati nella console del server. È buona norma allegare questo file nel caso chiedessi aiuto al nostro staff di supporto; in questo file non è mai presente la tua AuthKey quindi puoi inviarlo senza alcuna modifica.
+
+Il formato dei messaggi è spiegato di seguito:
+
+```
+[$DATA $ORA] $CONTESTO [$LIVELLO_DI_LOG] $MESSAGGIO
+```
+
+Dove:
+
+- `$DATA` è la data del messaggio, per esempio 21/07/2021
+- `$ORA` è l'ora del messaggio, per esempio 11:05:23
+- `$CONTESTO` (visibile soltanto se la variabile Debug è abilitata) è il contesto del messaggio che può essere:
+	- `(ID giocatore) “Nome Giocatore”`, dove l'ID del giocatore è utile per la moderazione
+	- Un nome corto come “HeartbeatThread”
+- `$LIVELLO_DI_LOG` è il livello di importanza del messaggio:
+	- `DEBUG`: Visibile solo se la variabile Debug è abilitata, importante solo per gli sviluppatori
+	- `INFO`: Informazioni generali
+	- `LUA`: Messaggio da un plugin Lua
+	- `WARN`: Descrive qualcosa che di solito non dovrebbe accadere
+	- `ERROR`: Descrive qualcosa che è andato storto, o un imprevisto
+	- `FATAL`: Descrive qualcosa che ha causato l'arresto del server
+- `$MESSAGGIO` il messaggio in se al quale devi prestare attenzione e capire. In alcuni casi il messaggio può essere criptico, ma in generale se il server funziona e non ci sono messaggi ERROR, non ci sono problemi.
+
+## Aggiornare il server
+
+### Perché aggiornare
+
+Quando un aggiornamento è rilasciato, è sempre consigliato aggiornare il server. Di solito le nuove versioni portano risoluzioni di bug, maggiore stabilità e correzioni di sicurezza senza dimenticare nuove funzionalità.
+
+Per rimanere aggiornato sulle nuove versioni, puoi seguire il canale "updates" sul nostro Discord, guardare sul nostro forum o guardare la [pagina delle release di GitHub](https://github.com/BeamMP/BeamMP-Server/releases).
+
+### Come aggiornare
+
+#### Se stai usando un fornitore di hosting partner
+
+Se stai usando un fornitore di hosting partner, le seguenti istruzioni non funzioneranno. Si consiglia di attendere ulteriori dettagli dal proprio fornitore di hosting o di contattarlo per ricevere assistenza.
+
+#### Gestire il server autonomamente
+
+Il server è aggiornabile cambiando l'eseguibile vecchio del server con quello nuovo. Se non sai come farlo, di seguito troverai le istruzioni.
+
+Se hai compilato i file sorgente, ri-compila di nuovo i file. Prima di ri-compilare i file esegui `git submodule update --init --recursive` in un terminale.
+
+#### Su Windows
+
+1. Assicurati di aver installato i [Visual C++ Redistributables](https://aka.ms/vs/17/release/vc_redist.x64.exe), necessari per eseguire il server.
+2. Scarica l'eseguibile del server da [beammp.com](https://www.beammp.com/). Dovresti trovarti con un file chiamato `BeamMP-Server.exe`.
+3. Chiameremo il file appena scaricato "nuovo eseguibile".
+4. Vai nella cartella dove è presente il corrente `BeamMP-Server.exe` (normalmente la stessa cartella con `ServerConfig.toml`). Chiameremo questo eseguibile "vecchio eseguibile".
+5. Sposta il nuovo eseguibile nella cartella di quello vecchio sovrascrivendolo.
+
+#### Su Linux
+
+1. Vai su [beammp.com](https://www.beammp.com/) e clicca il pulsante "Download server", sarai reindirizzato alla pagina Github delle release del server.
+2. Scarica la versione corretta per la tua distribuzione. Per semplicità sarà chiamata `BeamMP-Server-xxx` durante la guida, dove `xxx` è la versione per la distribuzione che stai usando.
+3. Chiameremo il file appena scaricato "nuovo eseguibile".
+4. Vai nella cartella dove è presente il corrente `BeamMP-Server-xxx` (normalmente la stessa cartella con `ServerConfig.toml`). Chiameremo questo eseguibile "vecchio eseguibile".
+5. Sposta il nuovo eseguibile nella cartella di quello vecchio sovrascrivendolo.
+6. Apri un terminale, naviga alla cartella dove si trova `BeamMP-Server-xxx` e incolla il comando `chmod +x BeamMP-Server-xxx`. Questo farà in modo che si abbiano i permessi per eseguire il server.
+
+### Aggiornamenti automatici
+
+Il server non supporta (ancora) gli aggiornamenti automatici.
+
+Puoi però vedere quale sia l'ultima versione disponibile tramite la API di GitHub, con una richiesta GET da `https://api.github.com/repos/BeamMP/BeamMP-Server/git/refs/tags`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -113,6 +113,7 @@ plugins:
             Using BeamMP: Usando BeamMP
             Running a Server: Ejecutando un Servidor
             Server Installation: Instalación del Servidor
+            Server Maintenance: Manutención del Servidor
             Server Manual: Manual del Servidor
             Mod & Resource Creation: Creación de Mods y Recursos
             Client Side: Lado del Cliente
@@ -148,6 +149,7 @@ plugins:
             Using BeamMP: BeamMP verwenden
             Running a Server: Server ausführen
             Server Installation: Server Installation
+            Server Maintenance: Server Wartung
             Server Manual: Server Handbuch
             Mod & Resource Creation: Mod- & Ressourcenerstellung
             Client Side: Clientseite
@@ -183,6 +185,7 @@ plugins:
             Using BeamMP: Utilisation de BeamMP
             Running a Server: Exécution d'un serveur
             Server Installation: Installation du serveur
+            Server Maintenance: Maintenance du serveur
             Server Manual: Manuel du serveur
             Mod & Resource Creation: Création de mods et de ressources
             Client Side: Côté client
@@ -218,6 +221,7 @@ plugins:
             Using BeamMP: Utilizzare BeamMP
             Running a Server: Eseguire un server
             Server Installation: Installazione del server
+            Server Maintenance: Manutenzione del server
             Server Manual: Manuale del server
             Mod & Resource Creation: Creazione di Mod e Risorse
             Client Side: Lato client
@@ -253,6 +257,7 @@ plugins:
             Using BeamMP: Использование BeamMP
             Running a Server: Запуск сервера
             Server Installation: Установка сервера
+            Server Maintenance: Обслуживание сервера
             Server Manual: Руководство по серверу
             Mod & Resource Creation: Создание модов и ресурсов
             Client Side: Сторона клиента
@@ -312,6 +317,7 @@ nav:
       - Using BeamMP: game/playing.md
     - Running a Server:
       - Server Installation: server/create-a-server.md
+      - Server Maintenance: server/server-maintenance.md
       - Server Manual: server/manual.md
     - Mod & Resource Creation:  
       - Client Side: guides/mod-creation/client/getting-started.md


### PR DESCRIPTION
Added:

- Migrated `server-maintenance` from the old wiki.
- Translated `server-maintenance` in Italian.
- Changed the links for the server maintenance in `create-a-server.md` from the wiki to the docs.