### PR TITLE
fix: FS.CreateDirectory returns true on success

### DIFF
--- a/docs/en/scripting/server-reference.md
+++ b/docs/en/scripting/server-reference.md
@@ -720,13 +720,13 @@ Please always use `/` as a separator when specifying paths, as this is cross-pla
 
 Creates the specified directory, and any parent directories if they don't exist. Behavior is roughly equivalent to the common linux command `mkdir -p`.
 
-Returns whether the operation had an error, and, if it *did*, an error message. This means that, if `true` is returned, an error occurred.
+If successful, returns `true` and `""`. If creating the directory failed, `false` and an error message (`string`) is returned.
 
 Example:
 ```lua
-local error, error_message = FS.CreateDirectory("data/mystuff/somefolder")
+local success, error_message = FS.CreateDirectory("data/mystuff/somefolder")
 
-if error then
+if not success then
 	print("failed to create directory: " .. error_message)
 else
 	-- do something with the directory

--- a/docs/en/scripting/server-reference.md
+++ b/docs/en/scripting/server-reference.md
@@ -731,6 +731,11 @@ if not success then
 else
 	-- do something with the directory
 end
+
+-- Be careful not to do this! This will ALWAYS be true!
+if error_message then
+	-- ...
+end
 ```
 
 #### `FS.Remove(path: string) -> bool,string`


### PR DESCRIPTION
I don't want to admit how long I spent finding this out 😆.

The first return value being `true` when an error **has** occurred seemed **very** inconsistent, but I took the docs as gospel, even though it is considered a war crime in Lua 😉. Checking the [source code](https://github.com/BeamMP/BeamMP-Server/blob/7f69e336a9fbf9fc13e641bf2a9882482599c9f5/src/LuaAPI.cpp#L350-L351) seems to show returning **`false`** when an **error has occurred, not `true`**.