### PR TITLE
Change wording of port forwarding risks

### DIFF
--- a/docs/en/server/create-a-server.md
+++ b/docs/en/server/create-a-server.md
@@ -28,13 +28,18 @@ _If you are on a VPS (Virtual Private Server) or Rootserver, you can skip this s
 
 This step is necessary if you want someone outside of your household to join ("outside of your local network").
 
-#### DISCLAIMER:
+####
+!!! danger ":material-scale-balance: DISCLAIMER:"
 
-By Port forwarding you understand the risks of opening up ports on your home network to the public and therefore void the right to hold BeamMP accountable for any (serious) damages that may happen to you or your household.
+    **Port forwarding is a risk**.
+
+    By Port forwarding you understand the risks of opening up ports on your home network to the public and therefore void the right to hold BeamMP accountable for **any and all** damages that may happen to you or your household.
+
+    We take no responsibility for any content on any externally linked services or websites.
 
 Therefore it is recommended to host a Server with one of our partnered Services!
 
-Paid Services:
+#### Paid Services:
 
 * [Horizon Hosting](https://hrzn.link/beammp)
 * [Snakecraft Hosting](https://schost.us/beammp-plans)

--- a/docs/en/server/port-forwarding.md
+++ b/docs/en/server/port-forwarding.md
@@ -1,0 +1,58 @@
+# Port Forwarding
+
+!!! danger ":material-scale-balance: DISCLAIMER:"
+
+    **Port forwarding is a risk**.
+
+    By Port forwarding you understand the risks of opening up ports on your home network to the public and therefore void the right to hold BeamMP accountable for **any and all** damages that may happen to you or your household.
+
+    We take no responsibility for any content on any externally linked services or websites.
+
+    <u>**If you do not understand how to do this. Please use one of our partners**</u>
+
+
+
+## How To Set Up a Port Forward
+
+Setting up a port forward involves a few detailed network terms. Be prepared to write down a few notes as you go through the process.
+
+There are 4 major steps to setting up a port forward.
+
+### A quick guide. (A more detailed guide is below)
+
+        
+        
+        
+
+<div class="grid cards" markdown>
+
+-   :material-dns:{ .lg .middle } __Assign a static IP address to your computer or devices__
+
+    ---
+    This is needed to prevent the IP of your device changing and breaking the port forwarding rule.
+    
+
+    [:octicons-arrow-right-24: See info about your router](https://portforward.com/router.htm#1)
+
+-   :material-router-wireless:{ .lg .middle } __Log in to your router__
+
+    ---
+
+    This can normally be done by finding the Default Gateway IP, which can be found using `ipconfig` in a CLI to and entering this in on a web browser.
+
+-   :material-lan-connect:{ .lg .middle } __Forward ports to your computer__
+
+    ---
+
+    Find the port forwarding section in your router menu. Most routers list the port forwarding section under Network, Advanced, or LAN.
+
+-   :material-test-tube:{ .lg .middle } __Test that your port is forwarded properly__
+
+    ---
+
+    Use a tool such as ProbablyUp to test if the rule is working.
+
+    [:octicons-arrow-right-24: Probably Up](https://probablyup.net/api)
+
+</div>
+

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -342,6 +342,7 @@ nav:
       - Server Maintenance: server/server-maintenance.md
       - Error Codes: server/error-codes.md
       - Server Manual: server/manual.md
+      - Port Forwarding: server/port-forwarding.md
     - Mod & Resource Creation:  
       - Client Side: guides/mod-creation/client/getting-started.md
       - Server Side: guides/mod-creation/server/getting-started.md


### PR DESCRIPTION
Changed wording of the risks of port forwarding and made it show up better:

![image](https://github.com/user-attachments/assets/ad7c8617-1829-4353-b614-5c068a9d749e)
