### PR TITLE
Change to CheckBeamMP

### DIFF
--- a/docs/de/FAQ/server-faq.md
+++ b/docs/de/FAQ/server-faq.md
@@ -40,7 +40,15 @@ Lies die Anleitung für das weiterleiten von Ports in [diesem Artikel](https://d
 - Stelle sicher, dass du keinen VPN verwendest (dies wird Probleme verursachen).
 - Stelle sicher, dass der Server ohne Probleme oder Fehlermeldungen läuft.
 
-Du kannst prüfen, ob du erfolgreich Ports weitergeleitet hast, indem du '[probablyup.net](https://probablyup.net/api)' verwendest während der Server läuft.
+Du kannst prüfen, ob du erfolgreich Ports weitergeleitet hast, indem du CheckBeamMP verwendest während der Server läuft.
+
+<form action="https://check.beammp.com/api/v2/beammp/" method="get" target="_blank">
+  <label for="ip">IP adress:</label>
+  <input type="text" id="ip" name="ip"><br>
+  <label for="port">Port:</label>
+  <input type="text" id="port" name="port"><br>
+  <input type="submit" value="CheckBeamMP">
+</form>
 
 Beachte:
 

--- a/docs/de/FAQ/where-to-find-my-IP.md
+++ b/docs/de/FAQ/where-to-find-my-IP.md
@@ -8,7 +8,15 @@ Wenn du einen Server mit einer unseren Partner Hosting Services hostest, wird di
 
 Für heim-gehostete Server, öffne [whatsmyip.org](https://whatsmyip.org) in einem Browser. Das wird die öffentliche IPv4 Adress ausgeben, mit der du vom Internet aus kontaktiert wirst.
 
-Beachte, dass 127.0.0.1 die Localhost Adresse ist und nur von dir verwendet werde kann, wenn der Server auf demselben Computer läuft. Wenn du immer noch Verbindungsprobleme mit deinem heim-Server hast, prüfe [probablyup.net](https://probablyup.net/api) und die [Port Weiterleitung Anleitung](https://docs.beammp.com/server/port-forwarding/)
+Beachte, dass 127.0.0.1 die Localhost Adresse ist und nur von dir verwendet werde kann, wenn der Server auf demselben Computer läuft. Wenn du immer noch Verbindungsprobleme mit deinem heim-Server hast, prüfe die [Port Weiterleitung](https://docs.beammp.com/server/port-forwarding/) sowie CheckBeamMP
+
+<form action="https://check.beammp.com/api/v2/beammp/" method="get" target="_blank">
+  <label for="ip">IP adress:</label>
+  <input type="text" id="ip" name="ip"><br>
+  <label for="port">Port:</label>
+  <input type="text" id="port" name="port"><br>
+  <input type="submit" value="CheckBeamMP">
+</form>
 
 ## Wie prüft man auf CGNAT?
 

--- a/docs/de/server/port-forwarding.md
+++ b/docs/de/server/port-forwarding.md
@@ -48,8 +48,14 @@ Diese Anleitung besteht aus vier Hauptschritten.
 <li data-md-type="list_item" data-md-list-type="unordered">
 <p data-md-type="paragraph">:material-test-tube:{ .lg .middle } <strong data-md-type="double_emphasis">Teste, ob dein Port richtig weitergeleitet wird</strong></p>
 <hr data-md-type="hrule">
-<p data-md-type="paragraph">Verwenden Sie ein Tool wie ProbablyUp, um zu testen, ob die Regel funktioniert.</p>
-<p data-md-type="paragraph"><a href="https://probablyup.net/api" data-md-type="link">:octacons-arrow-right-24: Wahrscheinlich oben</a></p>
+<p data-md-type="paragraph">Verwenden Sie ein Tool wie CheckBEamMP, um zu testen, ob die Regel funktioniert.</p>
+<p data-md-type="paragraph"><form action="https://check.beammp.com/api/v2/beammp/" method="get" target="_blank">
+  <label for="ip">IP adress:</label>
+  <input type="text" id="ip" name="ip"><br>
+  <label for="port">Port:</label>
+  <input type="text" id="port" name="port"><br>
+  <input type="submit" value="CheckBeamMP">
+</form></p>
 </li>
 </ul>
 <div data-md-type="block_html"></div>
@@ -189,7 +195,15 @@ Die meisten Router verfügen über eine Schaltfläche „Speichern“ und bei ma
 
 Es gibt verschiedene Möglichkeiten, die Verbindung zu testen.
 
-Wir empfehlen die Verwendung eines Tools namens **CheckBeamMP** , da dieses auf BeamMP-spezifische Probleme und Protokolle testet.
+Wir empfehlen die Verwendung unseres Tools **CheckBeamMP**, da dieses auf BeamMP-spezifische Probleme und Protokolle testet.
+
+<form action="https://check.beammp.com/api/v2/beammp/" method="get" target="_blank">
+  <label for="ip">IP adress:</label>
+  <input type="text" id="ip" name="ip"><br>
+  <label for="port">Port:</label>
+  <input type="text" id="port" name="port"><br>
+  <input type="submit" value="CheckBeamMP">
+</form>
 
 Dies kann durch die Abfrage deiner öffentlichen IPv4-Adresse erfolgen. Auch hierfür gibt es verschiedene Möglichkeiten. Die häufigste Methode ist die Nutzung der Website [whatsmyip.org](https://whatsmyip.org/) . Diese einfache Website zeigt deine öffentliche IP-Adresse an. Du solltest nach einer IP-Adresse im Format xxx.xxx.xxx.xxx suchen.
 
@@ -199,7 +213,7 @@ Besuche den folgenden Link und ersetzen Sie "IP" durch deine tatsächliche IPv4-
 
 ```
   Wenn du die obige Ausgabe erhältst, kannst du des jetzt deinem Server beitreten!
-Es gibt zwei Möglichkeiten, beizutreten: entweder direkt mit den Daten, die du in probablyup eingegeben hast, oder, wenn dein Server auf „öffentlich“ eingestellt ist, über die Serverliste.
+Es gibt zwei Möglichkeiten, beizutreten: entweder direkt mit den Daten, die du in CheckBeamMP eingegeben hast, oder, wenn dein Server auf „öffentlich“ eingestellt ist, über die Serverliste.
 Da du einen Server vor Ort hostest, verwenden 127.0.0.1 (localhost), wenn der Server auf demselben PC läuft, auf dem du spielst, oder die LAN-IPv4 des lokalen Computers, auf dem der Server läuft.
 ```
 

--- a/docs/de/support/server-faq.md
+++ b/docs/de/support/server-faq.md
@@ -40,7 +40,15 @@ Lies die Anleitung für das weiterleiten von Ports in [diesem Artikel](https://d
 - Stelle sicher, dass du keinen VPN verwendest (dies wird Probleme verursachen).
 - Stelle sicher, dass der Server ohne Probleme oder Fehlermeldungen läuft.
 
-Du kannst prüfen, ob du erfolgreich Ports weitergeleitet hast, indem du '[probablyup.net](https://probablyup.net/api)' verwendest während der Server läuft.
+Du kannst prüfen, ob du erfolgreich Ports weitergeleitet hast, indem du CheckBeamMP verwendest während der Server läuft.
+
+<form action="https://check.beammp.com/api/v2/beammp/" method="get" target="_blank">
+  <label for="ip">IP adress:</label>
+  <input type="text" id="ip" name="ip"><br>
+  <label for="port">Port:</label>
+  <input type="text" id="port" name="port"><br>
+  <input type="submit" value="CheckBeamMP">
+</form>
 
 Beachte:
 

--- a/docs/en/FAQ/server-faq.md
+++ b/docs/en/FAQ/server-faq.md
@@ -36,7 +36,15 @@ If other players, trying to connect to your server, receive an error code 10060,
 - Make sure you're not using a VPN (this can cause issues).
 - Make sure the server is actually running, without any errors or warnings.
 
-You can check if you have successfully portforwarded using the site '[probablyup.net](https://probablyup.net/api)' whilst the server is running.
+You can check if you have successfully portforwarded using CheckBeamMP whilst the server is running.
+
+<form action="https://check.beammp.com/api/v2/beammp/" method="get" target="_blank">
+  <label for="ip">IP adress:</label>
+  <input type="text" id="ip" name="ip"><br>
+  <label for="port">Port:</label>
+  <input type="text" id="port" name="port"><br>
+  <input type="submit" value="CheckBeamMP">
+</form>
 
 Notes:
 

--- a/docs/en/FAQ/where-to-find-my-IP.md
+++ b/docs/en/FAQ/where-to-find-my-IP.md
@@ -9,7 +9,15 @@ For Servers hosted at home, open [whatsmyip.org](https://whatsmyip.org) in a Bro
 This will output the public IPv4 address you are being contacted with from the Internet.
 
 Note, that 127.0.0.1 is the localhost address and can only be used by yourself, if the Server is hosted on the same Computer.
-If you are still having connection troubles with your home hosted server, check [probablyup.net](https://probablyup.net/api) and the [port forwarding guide](https://docs.beammp.com/server/port-forwarding/)
+If you are still having connection troubles with your home hosted server, check the [port forwardings](https://docs.beammp.com/server/port-forwarding/) as well as CheckBeamMP
+
+<form action="https://check.beammp.com/api/v2/beammp/" method="get" target="_blank">
+  <label for="ip">IP adress:</label>
+  <input type="text" id="ip" name="ip"><br>
+  <label for="port">Port:</label>
+  <input type="text" id="port" name="port"><br>
+  <input type="submit" value="CheckBeamMP">
+</form>
 
 ## How to check for CGNAT?
 Have a look at [this page](https://docs.beammp.com/FAQ/How-to-check-for-CGNAT/) to determine wether you can host a server at home or not.

--- a/docs/en/server/port-forwarding.md
+++ b/docs/en/server/port-forwarding.md
@@ -53,9 +53,15 @@ There are 4 major steps in this guide.
 
     ---
 
-    Use a tool such as ProbablyUp to test if the rule is working.
+    Use a tool such as CheckBeamMP to test if the rule is working.
 
-    [:octicons-arrow-right-24: Probably Up](https://probablyup.net/api)
+    <form action="https://check.beammp.com/api/v2/beammp/" method="get" target="_blank">
+     <label for="ip">IP adress:</label>
+     <input type="text" id="ip" name="ip"><br>
+     <label for="port">Port:</label>
+     <input type="text" id="port" name="port"><br>
+     <input type="submit" value="CheckBeamMP">
+    </form>
 
 </div>
 
@@ -224,7 +230,15 @@ Most routers have a 'save' button, and some routers require a restart or reboot 
 
 There are a few different ways to test the connection.
 
-Our recommend way is to use a tool called **CheckBeamMP** as this tests for BeamMP specific issues and protocols.
+Our recommend way is to use our tool **CheckBeamMP** as this tests for BeamMP specific issues and protocols.
+
+<form action="https://check.beammp.com/api/v2/beammp/" method="get" target="_blank">
+  <label for="ip">IP adress:</label>
+  <input type="text" id="ip" name="ip"><br>
+  <label for="port">Port:</label>
+  <input type="text" id="port" name="port"><br>
+  <input type="submit" value="CheckBeamMP">
+</form>
 
 This can be done by getting your public IPv4 Address, this once again can be done in a few different ways. The main way is to use a website called [whatsmyip.org](https://whatsmyip.org/). This is a simple website which displays your public IP Address. You should be looking for an IP address with the formatting: xxx.xxx.xxx.xxx
 

--- a/docs/fr/FAQ/server-faq.md
+++ b/docs/fr/FAQ/server-faq.md
@@ -36,7 +36,15 @@ Si d'autres joueurs essaient de se connecter et qu'ils reçoivent un code d'erre
 - Assurez-vous que vous n'utilisez pas de VPN (Cela peut causer des problèmes).
 - Assurez-vous que le logiciel serveur est lancé et qu'il ne donne pas d'erreurs ni d'avertissements.
 
-Vous pouvez vérifier si vous avez correctement configuré la redirection de port en utilisant le site '[probablyup.net](https://probablyup.net/api)' lorsque le serveur est lancé.
+Vous pouvez vérifier si vous avez correctement configuré la redirection de port en utilisant CheckBeamMP lorsque le serveur est lancé.
+
+<form action="https://check.beammp.com/api/v2/beammp/" method="get" target="_blank">
+  <label for="ip">IP adress:</label>
+  <input type="text" id="ip" name="ip"><br>
+  <label for="port">Port:</label>
+  <input type="text" id="port" name="port"><br>
+  <input type="submit" value="CheckBeamMP">
+</form>
 
 Notes:
 

--- a/docs/fr/support/server-faq.md
+++ b/docs/fr/support/server-faq.md
@@ -36,7 +36,15 @@ Si d'autres joueurs essaient de se connecter et qu'ils reçoivent un code d'erre
 - Assurez-vous que vous n'utilisez pas de VPN (Cela peut causer des problèmes).
 - Assurez-vous que le logiciel serveur est lancé et qu'il ne donne pas d'erreurs ni d'avertissements.
 
-Vous pouvez vérifier si vous avez correctement configuré la redirection de port en utilisant le site '[probablyup.net](https://probablyup.net/api)' lorsque le serveur est lancé.
+Vous pouvez vérifier si vous avez correctement configuré la redirection de port en utilisant CheckBeamMP lorsque le serveur est lancé.
+
+<form action="https://check.beammp.com/api/v2/beammp/" method="get" target="_blank">
+  <label for="ip">IP adress:</label>
+  <input type="text" id="ip" name="ip"><br>
+  <label for="port">Port:</label>
+  <input type="text" id="port" name="port"><br>
+  <input type="submit" value="CheckBeamMP">
+</form>
 
 Notes:
 


### PR DESCRIPTION
Changes all probablyup references to CheckBeamMP as well as adding a form to input IP and port

Requires the check.beammp.com api to accept key=value pairs

Feel free to change to a different method if this is not suitable