### PR TITLE
Update installation instructions for Fedora Linux

### DIFF
--- a/docs/de/game/getting-started.md
+++ b/docs/de/game/getting-started.md
@@ -34,7 +34,7 @@ Derzeit musst du den Launcher selbst erstellen. Dazu benötigst du grundlegende 
 Stelle sicher, dass [`vcpkg`](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started?pivots=shell-bash#1---set-up-vcpkg) sowie grundlegende Entwicklungstools installiert sind, welche oft in Paketen enthalten sind, zum Beispiel:
 
 - Debian: `sudo apt install build-essential`
-- Fedora: `sudo dnf install cmake gcc-c++ perl-IPC-Cmd perl-FindBin perl-File-Compare`
+- Fedora: `sudo dnf install cmake gcc-c++ perl-IPC-Cmd perl-FindBin perl-File-Compare perl-File-Copy`
 - Arch: `sudo pacman -S base-devel`
 - openSUSE: `zypper in -t pattern devel-basis`
 - SteamOS (Arch): `sudo pacman -S base-devel linux-api-headers glibc libconfig` (Du musst auch `sudo steamos-readonly disable` ausführen, schalte es jedoch nach der Installation wieder ein)

--- a/docs/de/game/getting-started.md
+++ b/docs/de/game/getting-started.md
@@ -34,7 +34,7 @@ Derzeit musst du den Launcher selbst erstellen. Dazu benötigst du grundlegende 
 Stelle sicher, dass [`vcpkg`](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started?pivots=shell-bash#1---set-up-vcpkg) sowie grundlegende Entwicklungstools installiert sind, welche oft in Paketen enthalten sind, zum Beispiel:
 
 - Debian: `sudo apt install build-essential`
-- Fedora: `sudo dnf install @development-tools`
+- Fedora: `sudo dnf install cmake gcc-c++ perl-IPC-Cmd perl-FindBin perl-File-Compare`
 - Arch: `sudo pacman -S base-devel`
 - openSUSE: `zypper in -t pattern devel-basis`
 - SteamOS (Arch): `sudo pacman -S base-devel linux-api-headers glibc libconfig` (Du musst auch `sudo steamos-readonly disable` ausführen, schalte es jedoch nach der Installation wieder ein)

--- a/docs/en/game/getting-started.md
+++ b/docs/en/game/getting-started.md
@@ -35,7 +35,7 @@ In order to do this, you need a basic understanding of how to build an applicati
 Make sure you have [`vcpkg` installed](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started?pivots=shell-bash#1---set-up-vcpkg), as well as basic development tools, often found in packages, for example:
 
 - Debian: `sudo apt install build-essential`
-- Fedora: `sudo dnf install @development-tools`
+- Fedora: `sudo dnf install cmake gcc-c++ perl-IPC-Cmd perl-FindBin perl-File-Compare`
 - Arch: `sudo pacman -S base-devel`
 - openSUSE: `zypper in -t pattern devel-basis`
 - SteamOS (Arch): `sudo pacman -S base-devel linux-api-headers glibc libconfig` (You also need to do `sudo steamos-readonly disable` but make sure to enable it again after installing the packages)

--- a/docs/en/game/getting-started.md
+++ b/docs/en/game/getting-started.md
@@ -35,7 +35,7 @@ In order to do this, you need a basic understanding of how to build an applicati
 Make sure you have [`vcpkg` installed](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started?pivots=shell-bash#1---set-up-vcpkg), as well as basic development tools, often found in packages, for example:
 
 - Debian: `sudo apt install build-essential`
-- Fedora: `sudo dnf install cmake gcc-c++ perl-IPC-Cmd perl-FindBin perl-File-Compare`
+- Fedora: `sudo dnf install cmake gcc-c++ perl-IPC-Cmd perl-FindBin perl-File-Compare perl-File-Copy`
 - Arch: `sudo pacman -S base-devel`
 - openSUSE: `zypper in -t pattern devel-basis`
 - SteamOS (Arch): `sudo pacman -S base-devel linux-api-headers glibc libconfig` (You also need to do `sudo steamos-readonly disable` but make sure to enable it again after installing the packages)

--- a/docs/fr/game/getting-started.md
+++ b/docs/fr/game/getting-started.md
@@ -35,7 +35,7 @@ Pour ce faire, vous avez besoin d'un minimum de connaissences de base pour const
 Assurez-vous d'avoir [`vcpkg`](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started?pivots=shell-bash#1---set-up-vcpkg) d'installé, ainse que des outil de dévelopement de base, souvent trouvé dans des packets (package) tel que (par exemple):
 
 - Debian: `sudo apt install build-essential`
-- Fedora: `sudo dnf install cmake gcc-c++ perl-IPC-Cmd perl-FindBin perl-File-Compare`
+- Fedora: `sudo dnf install cmake gcc-c++ perl-IPC-Cmd perl-FindBin perl-File-Compare perl-File-Copy`
 - Arch: `sudo pacman -S base-devel`
 - openSUSE: `zypper in -t pattern devel-basis`
 - SteamOS (Arch): `sudo pacman -S base-devel linux-api-headers glibc libconfig` (Vous devez également faire `sudo steamos-readonly disable` mais assurez-vous de l'activer à nouveau après l'installation des paquets.)

--- a/docs/fr/game/getting-started.md
+++ b/docs/fr/game/getting-started.md
@@ -35,7 +35,7 @@ Pour ce faire, vous avez besoin d'un minimum de connaissences de base pour const
 Assurez-vous d'avoir [`vcpkg`](https://learn.microsoft.com/en-us/vcpkg/get_started/get-started?pivots=shell-bash#1---set-up-vcpkg) d'installé, ainse que des outil de dévelopement de base, souvent trouvé dans des packets (package) tel que (par exemple):
 
 - Debian: `sudo apt install build-essential`
-- Fedora: `sudo dnf install @development-tools`
+- Fedora: `sudo dnf install cmake gcc-c++ perl-IPC-Cmd perl-FindBin perl-File-Compare`
 - Arch: `sudo pacman -S base-devel`
 - openSUSE: `zypper in -t pattern devel-basis`
 - SteamOS (Arch): `sudo pacman -S base-devel linux-api-headers glibc libconfig` (Vous devez également faire `sudo steamos-readonly disable` mais assurez-vous de l'activer à nouveau après l'installation des paquets.)


### PR DESCRIPTION
The previously recommended package group did not provide any of the necessary packages. Since the list of necessary dependencies is relatively short, I think they can all be listed individually. This way, the user does not need to perform any further troubleshooting.