### PR TITLE
Added 'export VCPKG_ROOT' to update part

### DIFF
--- a/docs/en/game/getting-started.md
+++ b/docs/en/game/getting-started.md
@@ -143,6 +143,7 @@ Note that this assumes you put the launcher's binary you compiled earlier into `
 If you already built the launcher and want to update it:
 
 ```bash
+export VCPKG_ROOT="$(pwd)/vcpkg"
 cd BeamMP-Launcher
 git fetch --tags
 ```


### PR DESCRIPTION
I didnt think of this, the exports are gone after an initial build and the user runs into problems when updating. I didnt put in the "export PATH=$VCPKG_ROOT:$PATH" because imho its not necessary